### PR TITLE
Relax dependencies on redis and bundler

### DIFF
--- a/resque-delayed.gemspec
+++ b/resque-delayed.gemspec
@@ -14,11 +14,11 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Resque::Delayed::VERSION
 
-  gem.add_development_dependency "bundler", [">= 1.0.2", "< 1.2.0"]
+  gem.add_development_dependency "bundler", ">= 1.0.2"
   gem.add_development_dependency "rspec", "~> 2.6.0"
   gem.add_development_dependency "rake", [">= 0.8.7", "< 1.0"]
 
-  gem.add_dependency "redis", [">= 2.2.0", "< 3.1.0"]
+  gem.add_dependency "redis", ">= 2.2.0"
   gem.add_dependency "resque", [">= 1.18.0", "< 2.0.0"]
   gem.add_dependency "uuidtools", "~> 2.1.2"
 end


### PR DESCRIPTION
Hi,

I'd like to use resque-delayed with more recent versions of the redis client gem, and bundler. This change relaxes those dependencies.

All specs passed.

Thanks,
Mike
