### PR TITLE
Minor changes to gemspec, dependencies and Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,10 @@
 #!/usr/bin/env rake
 
-$:.unshift File.dirname(__FILE__)
+begin
+  require 'bundler/setup'
+rescue LoadError => error
+  abort error.message
+end
+
 require "bundler/gem_tasks"
-require "lib/resque-delayed/tasks"
+require "resque-delayed/tasks"

--- a/Rakefile
+++ b/Rakefile
@@ -8,3 +8,6 @@ end
 
 require "bundler/gem_tasks"
 require "resque-delayed/tasks"
+
+require "rspec/core/rake_task"
+RSpec::Core::RakeTask.new

--- a/lib/resque-delayed.rb
+++ b/lib/resque-delayed.rb
@@ -1,6 +1,6 @@
 require 'resque'
 require 'uuidtools'
 
-%w(resque-delayed resque worker).each do |component|
-  require File.join(File.dirname(__FILE__), 'resque-delayed', component)
-end
+require 'resque-delayed/resque-delayed'
+require 'resque-delayed/resque'
+require 'resque-delayed/worker'

--- a/lib/resque/delayed.rb
+++ b/lib/resque/delayed.rb
@@ -1,0 +1,1 @@
+require 'resque-delayed'

--- a/resque-delayed.gemspec
+++ b/resque-delayed.gemspec
@@ -1,4 +1,7 @@
-require File.expand_path('../lib/resque-delayed/version', __FILE__)
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'resque-delayed/version'
 
 Gem::Specification.new do |gem|
   gem.authors       = ["Justin Giancola"]
@@ -7,9 +10,9 @@ Gem::Specification.new do |gem|
   gem.description   = %q{Enqueue jobs that will only appear for processing after a specified delay or at a particular time in the future}
   gem.homepage      = "https://github.com/elucid/resque-delayed"
 
-  gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  gem.files         = `git ls-files`.split("\n")
-  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+  gem.executables   = `git ls-files -- bin/*`.split($/).map { |f| File.basename(f) }
+  gem.files         = `git ls-files`.split($/)
+  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split($/)
   gem.name          = "resque-delayed"
   gem.require_paths = ["lib"]
   gem.version       = Resque::Delayed::VERSION

--- a/resque-delayed.gemspec
+++ b/resque-delayed.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rspec", "~> 2.6.0"
   gem.add_development_dependency "rake"
 
-  gem.add_dependency "resque", [">= 1.18.0", "< 2.0.0"]
+  gem.add_dependency "resque", ["~> 1.0", ">= 1.18.0"]
   gem.add_dependency "uuidtools", "~> 2.1.2"
 end

--- a/resque-delayed.gemspec
+++ b/resque-delayed.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rake"
 
   gem.add_dependency "resque", ["~> 1.0", ">= 1.18.0"]
-  gem.add_dependency "uuidtools", "~> 2.1.2"
+  gem.add_dependency "uuidtools", ["~> 2.1", ">= 2.1.2"]
 end

--- a/resque-delayed.gemspec
+++ b/resque-delayed.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Resque::Delayed::VERSION
 
-  gem.add_development_dependency "bundler", [">= 1.0.2", "< 1.2.0"]
+  gem.add_development_dependency "bundler", ["~> 1.0", ">= 1.0.2"]
   gem.add_development_dependency "rspec", "~> 2.6.0"
   gem.add_development_dependency "rake"
 

--- a/resque-delayed.gemspec
+++ b/resque-delayed.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rspec", "~> 2.6.0"
   gem.add_development_dependency "rake", [">= 0.8.7", "< 1.0"]
 
-  gem.add_dependency "redis", [">= 2.2.0", "< 3.1.0"]
   gem.add_dependency "resque", [">= 1.18.0", "< 2.0.0"]
   gem.add_dependency "uuidtools", "~> 2.1.2"
 end

--- a/resque-delayed.gemspec
+++ b/resque-delayed.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "bundler", [">= 1.0.2", "< 1.2.0"]
   gem.add_development_dependency "rspec", "~> 2.6.0"
-  gem.add_development_dependency "rake", [">= 0.8.7", "< 1.0"]
+  gem.add_development_dependency "rake"
 
   gem.add_dependency "resque", [">= 1.18.0", "< 2.0.0"]
   gem.add_dependency "uuidtools", "~> 2.1.2"

--- a/resque-delayed.gemspec
+++ b/resque-delayed.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["justin.giancola@gmail.com"]
   gem.summary       = %q{Delayed job queueing for Resque}
   gem.description   = %q{Enqueue jobs that will only appear for processing after a specified delay or at a particular time in the future}
-  gem.homepage      = "https://github.com/elucid/resque-delayed"
+  gem.homepage      = "https://github.com/elucid/resque-delayed#readme"
 
   gem.executables   = `git ls-files -- bin/*`.split($/).map { |f| File.basename(f) }
   gem.files         = `git ls-files`.split($/)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,6 @@
 
 require 'rubygems'
 require 'bundler'
-Bundler.setup
 Bundler.require
 
 # this is necessary because of


### PR DESCRIPTION
In order to use resque-delayed with recent versions of redis, resque and rake, I had to relax the dependencies. I also updated the gemspec and Rakefile.
